### PR TITLE
Typo fix poitner -> pointer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,4 @@ License: MIT + file LICENSE
 NeedsCompilation: yes
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/R/xptr.R
+++ b/R/xptr.R
@@ -92,7 +92,7 @@ set_xptr_address <- function(s, p) {
     invisible(.Call("set_xptr_address", PACKAGE = "xptr", s, p))
 }
 
-#' Set a tag to the external poitner.
+#' Set a tag to the external pointer.
 #' @param s an \code{externalptr} object
 #' @param tag an R object
 #' @export
@@ -100,7 +100,7 @@ set_xptr_tag <- function(s, tag) {
     invisible(.Call("set_xptr_tag", PACKAGE = "xptr", s, tag))
 }
 
-#' Set a protected R object to the external poitner.
+#' Set a protected R object to the external pointer.
 #' @param s an \code{externalptr} object
 #' @param protected an R object
 #' @export
@@ -108,7 +108,7 @@ set_xptr_protected <- function(s, protected) {
     invisible(.Call("set_xptr_protected", PACKAGE = "xptr", s, protected))
 }
 
-#' Register a finalizer for external poitner.
+#' Register a finalizer for external pointer.
 #' @param s an \code{externalptr} object
 #' @param f an R function
 #' @param onexit should the finalizer execute on exit?

--- a/man/register_xptr_finalizer.Rd
+++ b/man/register_xptr_finalizer.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/xptr.R
 \name{register_xptr_finalizer}
 \alias{register_xptr_finalizer}
-\title{Register a finalizer for external poitner.}
+\title{Register a finalizer for external pointer.}
 \usage{
 register_xptr_finalizer(s, f, onexit = FALSE)
 }
@@ -14,7 +14,7 @@ register_xptr_finalizer(s, f, onexit = FALSE)
 \item{onexit}{should the finalizer execute on exit?}
 }
 \description{
-Register a finalizer for external poitner.
+Register a finalizer for external pointer.
 }
 \seealso{
 \code{\link[base]{reg.finalizer}}

--- a/man/set_xptr_protected.Rd
+++ b/man/set_xptr_protected.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/xptr.R
 \name{set_xptr_protected}
 \alias{set_xptr_protected}
-\title{Set a protected R object to the external poitner.}
+\title{Set a protected R object to the external pointer.}
 \usage{
 set_xptr_protected(s, protected)
 }
@@ -12,5 +12,5 @@ set_xptr_protected(s, protected)
 \item{protected}{an R object}
 }
 \description{
-Set a protected R object to the external poitner.
+Set a protected R object to the external pointer.
 }

--- a/man/set_xptr_tag.Rd
+++ b/man/set_xptr_tag.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/xptr.R
 \name{set_xptr_tag}
 \alias{set_xptr_tag}
-\title{Set a tag to the external poitner.}
+\title{Set a tag to the external pointer.}
 \usage{
 set_xptr_tag(s, tag)
 }
@@ -12,5 +12,5 @@ set_xptr_tag(s, tag)
 \item{tag}{an R object}
 }
 \description{
-Set a tag to the external poitner.
+Set a tag to the external pointer.
 }


### PR DESCRIPTION
Looking at the documentation I spotted a simple repeat typo so here is a quick fix in the R file, plus the updated Rd files (and this also incremented the roxygen field in DESCRIPTION). 

I left the pkgdown documentation alone in case you have a special way to call.
